### PR TITLE
Chore: 각 api Restful 하게 변경 (추가 api 구현)

### DIFF
--- a/src/domain/photo/dto/request/create-photo.dto.ts
+++ b/src/domain/photo/dto/request/create-photo.dto.ts
@@ -1,18 +1,26 @@
 import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreatePhotoDto {
+  @ApiProperty({
+    example: 'https://s3.bucket.com/image1.jpg',
+    description: '사진의 S3 URL',
+  })
   @IsNotEmpty()
   @IsString()
   readonly s3imageUrl: string;
 
+  @ApiProperty({ example: '푸앙이', description: '사진의 이름' })
   @IsNotEmpty()
   @IsString()
   readonly name: string;
 
+  @ApiProperty({ example: '2021-10-10', description: '사진이 생성된 날짜' })
   @IsNotEmpty()
   @IsDate()
   readonly createdDate: Date;
 
+  @ApiProperty({ example: 1, description: '사진을 소유한 가족의 고유 ID' })
   @IsNotEmpty()
   @IsNumber()
   readonly familyId: number;

--- a/src/domain/photo/dto/request/update-photo.dto.ts
+++ b/src/domain/photo/dto/request/update-photo.dto.ts
@@ -1,8 +1,10 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreatePhotoDto } from './create-photo.dto';
 import { IsNotEmpty, IsNumber } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdatePhotoDto extends PartialType(CreatePhotoDto) {
+  @ApiProperty({ example: 1, description: '사진의 고유 ID' })
   @IsNotEmpty()
   @IsNumber()
   photoId: number;

--- a/src/domain/photo/dto/response/response-photo.dto.ts
+++ b/src/domain/photo/dto/response/response-photo.dto.ts
@@ -1,7 +1,17 @@
+import { Photo } from '../../../../infra/entities';
+import { ApiProperty } from '@nestjs/swagger';
+
 export class ResponsePhotoDto {
+  @ApiProperty({ example: 1, description: '사진 ID' })
   readonly photoId: number;
+
+  @ApiProperty({ example: '푸앙이의 사진', description: '사진 이름' })
   readonly photoName: string;
+
+  @ApiProperty({ example: 'http://s3.com/puang.jpg', description: '사진 URL' })
   readonly photoUrl: string;
+
+  @ApiProperty({ example: '2021-01-01', description: '사진 생성 날짜' })
   readonly createdDate: Date;
 
   constructor(
@@ -22,5 +32,14 @@ export class ResponsePhotoDto {
     createdDate: Date,
   ): ResponsePhotoDto {
     return new ResponsePhotoDto(photoId, photoName, photoUrl, createdDate);
+  }
+
+  static from(photo: Photo): ResponsePhotoDto {
+    return new ResponsePhotoDto(
+      photo.id,
+      photo.name,
+      photo.s3ImageUrl,
+      photo.createdDate,
+    );
   }
 }

--- a/src/domain/photo/photo.controller.ts
+++ b/src/domain/photo/photo.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Post, Query } from '@nestjs/common';
+import {Body, Controller, Delete, Get, Post, Put, Query} from '@nestjs/common';
 import { CreatePhotoDto, PhotoService, UpdatePhotoDto } from '../photo';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ApiResponse, ResponseCode } from '../../common';
@@ -25,13 +25,13 @@ export class PhotoController {
     summary: '사진 삭제',
     description: '사진을 삭제한다.',
   })
-  async deletePhoto(@Query() photoId: number) {
+  async deletePhoto(@Query('photoId') photoId: number) {
     await this.photoService.deletePhoto(photoId);
     return ApiResponse.success(ResponseCode.PHOTO_DELETE_SUCCESS, null);
   }
 
   //사진 수정
-  @Post('/update')
+  @Put('')
   @ApiOperation({
     summary: '사진 수정',
     description: '사진을 수정한다.',
@@ -45,12 +45,13 @@ export class PhotoController {
   @Get('/list')
   @ApiOperation({
     summary: '사진 리스트 반환',
-    description: '사진 리스트를 반환한다.',
+    description:
+      '사진 리스트를 반환한다. 가족 Id와 페이지, 한 페이지당 사진 개수를 Query parameter로 받는다.',
   })
   async getPhotos(
-    @Query() familyId: number,
-    @Query() page: number,
-    @Query() limit: number,
+    @Query('familyId') familyId: number,
+    @Query('page') page: number,
+    @Query('limit') limit: number,
   ) {
     const photos = await this.photoService.getPhotos(familyId, page, limit);
     return ApiResponse.success(ResponseCode.PHOTO_READ_SUCCESS, photos);

--- a/src/domain/photo/photo.controller.ts
+++ b/src/domain/photo/photo.controller.ts
@@ -1,15 +1,58 @@
-import { Controller } from '@nestjs/common';
-import { PhotoService } from '../photo';
+import { Body, Controller, Delete, Get, Post, Query } from '@nestjs/common';
+import { CreatePhotoDto, PhotoService, UpdatePhotoDto } from '../photo';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiResponse, ResponseCode } from '../../common';
 
+@ApiTags('사진 API')
 @Controller('photo')
 export class PhotoController {
   constructor(private readonly photoService: PhotoService) {}
 
   //사진 업로드
+  @Post('')
+  @ApiOperation({
+    summary: '사진 업로드',
+    description: '사진을 업로드한다.',
+  })
+  async createPhoto(@Body() createPhotoDto: CreatePhotoDto) {
+    const photoId = await this.photoService.createPhoto(createPhotoDto);
+    return ApiResponse.success(ResponseCode.PHOTO_CREATED_SUCCESS, photoId);
+  }
 
   //사진 삭제
+  @Delete('')
+  @ApiOperation({
+    summary: '사진 삭제',
+    description: '사진을 삭제한다.',
+  })
+  async deletePhoto(@Query() photoId: number) {
+    await this.photoService.deletePhoto(photoId);
+    return ApiResponse.success(ResponseCode.PHOTO_DELETE_SUCCESS, null);
+  }
 
   //사진 수정
+  @Post('/update')
+  @ApiOperation({
+    summary: '사진 수정',
+    description: '사진을 수정한다.',
+  })
+  async updatePhoto(@Body() updatePhotoDto: UpdatePhotoDto) {
+    await this.photoService.updatePhotoInfo(updatePhotoDto);
+    return ApiResponse.success(ResponseCode.PHOTO_UPDATE_SUCCESS, null);
+  }
 
   //사진 리스트 반환 (pagination 적용)
+  @Get('/list')
+  @ApiOperation({
+    summary: '사진 리스트 반환',
+    description: '사진 리스트를 반환한다.',
+  })
+  async getPhotos(
+    @Query() familyId: number,
+    @Query() page: number,
+    @Query() limit: number,
+  ) {
+    const photos = await this.photoService.getPhotos(familyId, page, limit);
+    return ApiResponse.success(ResponseCode.PHOTO_READ_SUCCESS, photos);
+  }
 }

--- a/src/domain/post/dto/request/create-post.dto.ts
+++ b/src/domain/post/dto/request/create-post.dto.ts
@@ -1,18 +1,26 @@
 import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreatePostDto {
+  @ApiProperty({
+    example: 1,
+    description: '포스트를 작성한 가족 구성원의 고유 ID',
+  })
   @IsNotEmpty()
   @IsNumber()
   readonly srcMemberId: number;
 
+  @ApiProperty({ example: '푸앙이', description: '포스트의 제목' })
   @IsNotEmpty()
   @IsString()
   readonly title: string;
 
+  @ApiProperty({ example: '푸앙이가 먹는 모습', description: '포스트의 내용' })
   @IsNotEmpty()
   @IsString()
   readonly context: string;
 
+  @ApiProperty({ example: '2021-10-10', description: '포스트가 작성된 날짜' })
   @IsNotEmpty()
   @IsString()
   readonly createdDate: Date;

--- a/src/domain/post/dto/response/response-post.dto.ts
+++ b/src/domain/post/dto/response/response-post.dto.ts
@@ -1,8 +1,23 @@
+import { Post } from '../../../../infra/entities';
+import { ApiProperty } from '@nestjs/swagger';
+
 export class ResponsePostDto {
+  @ApiProperty({ example: 1, description: '포스트의 고유 ID' })
   readonly postId: number;
-  readonly familyId: number;
-  readonly s3ImageUrl: string;
-  readonly name: string;
+
+  @ApiProperty({
+    example: 1,
+    description: '포스트를 작성한 가족 구성원의 고유 ID',
+  })
+  readonly familyMemberId: number;
+
+  @ApiProperty({ example: '푸앙이', description: '포스트의 제목' })
+  readonly title: string;
+
+  @ApiProperty({ example: '푸앙이가 먹는 모습', description: '포스트의 내용' })
+  readonly context: string;
+
+  @ApiProperty({ example: '2021-10-10', description: '포스트가 작성된 날짜' })
   readonly createdDate: Date;
 
   private constructor(
@@ -13,19 +28,29 @@ export class ResponsePostDto {
     createdDate: Date,
   ) {
     this.postId = postId;
-    this.familyId = familyId;
-    this.s3ImageUrl = s3ImageUrl;
-    this.name = name;
+    this.familyMemberId = familyId;
+    this.title = s3ImageUrl;
+    this.context = name;
     this.createdDate = createdDate;
   }
 
   static of(
     postId: number,
     familyId: number,
-    s3ImageUrl: string,
-    name: string,
+    title: string,
+    context: string,
     createdDate: Date,
   ): ResponsePostDto {
-    return new ResponsePostDto(postId, familyId, s3ImageUrl, name, createdDate);
+    return new ResponsePostDto(postId, familyId, title, context, createdDate);
+  }
+
+  static from(post: Post) {
+    return ResponsePostDto.of(
+      post.id,
+      post.srcMember.family.id,
+      post.title,
+      post.context,
+      post.createdDate,
+    );
   }
 }

--- a/src/domain/post/dto/response/response-post.dto.ts
+++ b/src/domain/post/dto/response/response-post.dto.ts
@@ -47,7 +47,7 @@ export class ResponsePostDto {
   static from(post: Post) {
     return ResponsePostDto.of(
       post.id,
-      post.srcMember.family.id,
+      post.srcMember.id,
       post.title,
       post.context,
       post.createdDate,

--- a/src/domain/post/post.controller.ts
+++ b/src/domain/post/post.controller.ts
@@ -13,7 +13,7 @@ import {
   ResponsePostDto,
   UpdatePostDto,
 } from '../post';
-import {ApiOperation, ApiTags} from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CustomApiCreatedResponse } from '../../common/api/response-created.decorator';
 import { ApiResponse, ResponseCode } from '../../common';
 import { CustomApiOKResponse } from '../../common/api/response-ok.decorator';
@@ -63,7 +63,7 @@ export class PostController {
     Number,
     '포스트를 삭제하면 포스트의 고유 ID를 integer로 반환한다.',
   )
-  async deletePost(@Query() postId: number) {
+  async deletePost(@Query('postId') postId: number) {
     await this.postService.deletePost(postId);
     return ApiResponse.success(ResponseCode.POST_DELETE_SUCCESS, null);
   }

--- a/src/domain/post/post.controller.ts
+++ b/src/domain/post/post.controller.ts
@@ -1,15 +1,86 @@
-import { Controller } from '@nestjs/common';
-import { PostService } from '../post';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import {
+  CreatePostDto,
+  PostService,
+  ResponsePostDto,
+  UpdatePostDto,
+} from '../post';
+import {ApiOperation, ApiTags} from '@nestjs/swagger';
+import { CustomApiCreatedResponse } from '../../common/api/response-created.decorator';
+import { ApiResponse, ResponseCode } from '../../common';
+import { CustomApiOKResponse } from '../../common/api/response-ok.decorator';
 
+@ApiTags('게시글 API')
 @Controller('post')
 export class PostController {
   constructor(private readonly postService: PostService) {}
 
   //포스트 등록
+  @Post('')
+  @ApiOperation({
+    summary: '포스트 등록',
+    description: '포스트를 등록한다.',
+  })
+  @CustomApiCreatedResponse(
+    Number,
+    '포스트를 등록하면 포스트의 고유 ID를 integer로 반환한다.',
+  )
+  async createPost(@Body() createPostDto: CreatePostDto) {
+    const postId = await this.postService.createPost(createPostDto);
+    return ApiResponse.success(ResponseCode.POST_CREATED_SUCCESS, postId);
+  }
 
   //포스트 수정
+  @Put('')
+  @ApiOperation({
+    summary: '포스트 수정',
+    description: '포스트를 수정한다.',
+  })
+  @CustomApiCreatedResponse(
+    Number,
+    '포스트를 수정하면 포스트의 고유 ID를 integer로 반환한다.',
+  )
+  async updatePost(@Body() updatePostDto: UpdatePostDto) {
+    await this.postService.updatePost(updatePostDto);
+    return ApiResponse.success(ResponseCode.POST_UPDATE_SUCCESS, null);
+  }
 
   //포스트 삭제
+  @Delete('')
+  @ApiOperation({
+    summary: '포스트 삭제',
+    description: '포스트를 삭제한다.',
+  })
+  @CustomApiCreatedResponse(
+    Number,
+    '포스트를 삭제하면 포스트의 고유 ID를 integer로 반환한다.',
+  )
+  async deletePost(@Query() postId: number) {
+    await this.postService.deletePost(postId);
+    return ApiResponse.success(ResponseCode.POST_DELETE_SUCCESS, null);
+  }
 
   //포스트 리스트 반환
+  @Get('')
+  @ApiOperation({
+    summary: '포스트 리스트 반환',
+    description: '포스트 리스트를 반환한다.',
+  })
+  @CustomApiOKResponse(ResponsePostDto, '포스트 리스트를 반환한다.')
+  async findPostList(@Query('id') familyId: number) {
+    const responsePostDtoList: ResponsePostDto[] =
+      await this.postService.findPostListByMemberId(familyId);
+    return ApiResponse.success(
+      ResponseCode.POST_READ_SUCCESS,
+      responsePostDtoList,
+    );
+  }
 }

--- a/src/domain/post/post.service.ts
+++ b/src/domain/post/post.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { CreatePostDto, UpdatePostDto } from './dto';
+import { CreatePostDto, ResponsePostDto, UpdatePostDto } from './dto';
 import { FamilyMember, Post } from '../../infra/entities';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -36,6 +36,16 @@ export class PostService {
     post.context = updatePostDto.context;
 
     await this.postRepository.save(post);
+  }
+
+  async findPostListByMemberId(
+    familyMemberId: number,
+  ): Promise<ResponsePostDto[]> {
+    await this.validateFamilyMember(familyMemberId);
+    const postList = await this.postRepository.find({
+      where: { srcMember: { id: familyMemberId } },
+    });
+    return postList.map((post) => ResponsePostDto.from(post));
   }
 
   async deletePost(postId: number) {

--- a/src/domain/user/user.controller.ts
+++ b/src/domain/user/user.controller.ts
@@ -58,7 +58,10 @@ export class UserController {
 
   //유저 로그인
   @Post('/login')
-  @ApiOperation({ summary: '유저 로그인', description: '이메일과 비밀번호를 통해 로그인한다.' })
+  @ApiOperation({
+    summary: '유저 로그인',
+    description: '이메일과 비밀번호를 통해 로그인한다.',
+  })
   @ApiBody({ type: LoginUserDto })
   @UseGuards(LocalServiceAuthGuard)
   @CustomApiOKResponse(

--- a/src/test/e2e/family-member.e2e.spec.ts
+++ b/src/test/e2e/family-member.e2e.spec.ts
@@ -97,7 +97,7 @@ describe('FamilyMemberController (e2e)', () => {
   it('should delete familyMember with path: /familymember/delete (Delete)', async () => {
     const response = await request(app.getHttpServer())
       .delete('/family-member')
-        .query({ id: 1 })
+      .query({ id: 1 })
       .expect(200);
 
     expect(response.body.message).toEqual('가족 구성원 삭제 성공');
@@ -106,7 +106,7 @@ describe('FamilyMemberController (e2e)', () => {
   it('should get Family info with member id', async () => {
     const response = await request(app.getHttpServer())
       .get('/family-member')
-        .query({ id: 1 })
+      .query({ id: 1 })
       .expect(200);
     expect(response.body.message).toEqual('가족 조회 성공');
     expect(response.body.data.familyName).toEqual('test');

--- a/src/test/e2e/family-schedule.e2e.spec.ts
+++ b/src/test/e2e/family-schedule.e2e.spec.ts
@@ -99,7 +99,7 @@ describe('FamilyScheduleController', () => {
   it('should delete FamilySchedule with path: /delete/:id (DELETE)', async () => {
     const response = await request(app.getHttpServer())
       .delete('/family-schedule')
-.query({ id: 1 })
+      .query({ id: 1 })
       .expect(200);
 
     expect(mockFamilyScheduleService.deleteFamilySchedule).toBeCalled();
@@ -109,7 +109,7 @@ describe('FamilyScheduleController', () => {
   it('should return familySchedule info with path: /:id (GET)', async () => {
     const response = await request(app.getHttpServer())
       .get('/family-schedule')
-        .query({ id: 1 })
+      .query({ id: 1 })
       .expect(200);
 
     expect(response.body.message).toEqual('가족 일정 조회 성공');

--- a/src/test/e2e/family.e2e.spec.ts
+++ b/src/test/e2e/family.e2e.spec.ts
@@ -48,7 +48,7 @@ describe('FamilyController (e2e)', () => {
   it('should return family info with path: /family (GET)', async () => {
     const response = await request(app.getHttpServer())
       .get('/family')
-        .query({ id: 1 })
+      .query({ id: 1 })
       .expect(200);
 
     expect(response.body.message).toEqual('가족 조회 성공');
@@ -59,7 +59,7 @@ describe('FamilyController (e2e)', () => {
   it('should return family info with path: /family/keycode (GET)', async () => {
     const response = await request(app.getHttpServer())
       .get('/family/join')
-        .query({ keyCode: 'testKeyCode' })
+      .query({ keyCode: 'testKeyCode' })
       .expect(200);
 
     expect(response.body.message).toEqual('가족 조회 성공');
@@ -89,7 +89,7 @@ describe('FamilyController (e2e)', () => {
   it('should return status code 200 when delete family', async () => {
     const response = await request(app.getHttpServer())
       .delete('/family')
-        .query({ id: 1 })
+      .query({ id: 1 })
       .expect(200);
 
     expect(response.body.message).toEqual('가족 삭제 성공');

--- a/src/test/e2e/interaction.e2e.spec.ts
+++ b/src/test/e2e/interaction.e2e.spec.ts
@@ -79,7 +79,7 @@ describe('InteractionController', () => {
     //given
     const response = await request(app.getHttpServer())
       .get('/interaction')
-        .query({ memberId: 2 })
+      .query({ memberId: 2 })
       .expect(200);
 
     expect(response.body.message).toEqual('상호작용 조회 성공');
@@ -92,7 +92,7 @@ describe('InteractionController', () => {
     //given
     const response = await request(app.getHttpServer())
       .delete('/interaction')
-        .query({ memberId: 2 })
+      .query({ memberId: 2 })
       .expect(200);
 
     expect(response.body.message).toEqual('상호작용 삭제 성공');

--- a/src/test/e2e/photo.e2e.spec.ts
+++ b/src/test/e2e/photo.e2e.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { Family, Photo } from '../../infra/entities';
+import { Repository } from 'typeorm';
+import { PhotoModule } from '../../module';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import * as request from 'supertest';
+import { PhotoService, ResponsePhotoDto } from '../../domain/photo';
+
+describe('PhotoController (e2e)', () => {
+  let app: INestApplication;
+  let mockPhotoService: Partial<PhotoService>;
+  let mockPhotoRepository: Partial<Repository<Photo>>;
+  let mockFamilyRepository: Partial<Repository<Family>>;
+
+  const photo: Photo = Photo.createPhoto(
+    'test.com',
+    'test',
+    Family.createFamily('test', 'testKeyCode'),
+  );
+  photo.id = 1;
+
+  beforeEach(async () => {
+    mockPhotoService = {
+      createPhoto: jest.fn().mockResolvedValue(1),
+      updatePhotoInfo: jest.fn(),
+      deletePhoto: jest.fn(),
+      getPhotos: jest.fn().mockResolvedValue([ResponsePhotoDto.from(photo)]),
+      getPhotoInfo: jest.fn().mockResolvedValue(ResponsePhotoDto.from(photo)),
+    };
+    mockPhotoRepository = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+    mockFamilyRepository = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [PhotoModule],
+    })
+      .overrideProvider(PhotoService)
+      .useValue(mockPhotoService)
+      .overrideProvider(getRepositoryToken(Photo))
+      .useValue(mockPhotoRepository)
+      .overrideProvider(getRepositoryToken(Family))
+      .useValue(mockFamilyRepository)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('should be defined', () => {
+    expect(app).toBeDefined();
+  });
+
+  it('should create photo', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/photo')
+      .send({
+        s3imageUrl: 'test',
+        name: 'test',
+        createdDate: new Date(),
+        familyId: 1,
+      })
+      .expect(201);
+
+    expect(response.body.message).toBe('사진 생성 성공');
+    expect(response.body.data).toBe(1);
+  });
+
+  it('should update photo', async () => {
+    const response = await request(app.getHttpServer())
+      .put('/photo')
+      .send({
+        photoId: 1,
+        name: 'test',
+      })
+      .expect(200);
+
+    expect(response.body.message).toBe('사진 정보 수정 성공');
+  });
+
+  it('should delete post', async () => {
+    const response = await request(app.getHttpServer())
+      .delete('/photo')
+      .query({ photoId: 1 })
+      .expect(200);
+
+    expect(response.body.message).toBe('사진 삭제 성공');
+  });
+
+  it('should get photos', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/photo/list')
+      .query({ familyId: 1, page: 1, limit: 10 })
+      .expect(200);
+
+    expect(response.body.message).toBe('사진 조회 성공');
+    expect(response.body.data[0].photoId).toEqual(1);
+    expect(response.body.data[0].photoName).toEqual('test');
+    expect(response.body.data[0].photoUrl).toEqual('test.com');
+  });
+});

--- a/src/test/e2e/post.e2e.spec.ts
+++ b/src/test/e2e/post.e2e.spec.ts
@@ -1,10 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { PostService } from '../../domain/post';
+import { PostService, ResponsePostDto } from '../../domain/post';
 import { INestApplication } from '@nestjs/common';
 import { FamilyMember, Post } from '../../infra/entities';
 import { Repository } from 'typeorm';
 import { PostModule } from '../../module';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import * as request from 'supertest';
 
 describe('PostController (e2e)', () => {
   let app: INestApplication;
@@ -12,11 +13,21 @@ describe('PostController (e2e)', () => {
   let mockPostRepository: Partial<Repository<Post>>;
   let mockFamilyMemberRepository: Partial<Repository<FamilyMember>>;
 
+  const post: Post = Post.createPost(
+    'testTitle',
+    'testContext',
+    new Date(),
+    FamilyMember.createFamilyMember(1, null, null),
+  );
+
   beforeEach(async () => {
     mockPostService = {
       createPost: jest.fn().mockResolvedValue(1),
       updatePost: jest.fn(),
       deletePost: jest.fn(),
+      findPostListByMemberId: jest
+        .fn()
+        .mockResolvedValue([ResponsePostDto.from(post)]),
     };
     mockPostRepository = {
       findOne: jest.fn(),
@@ -45,4 +56,43 @@ describe('PostController (e2e)', () => {
   it('should be defined', () => {
     expect(app).toBeDefined();
   });
+
+  it('should create post', async () => {
+    const response = await request(app.getHttpServer()).post('/post').send({
+      srcMemberId: 1,
+      title: 'test',
+      context: 'testContext',
+      createdDate: new Date(),
+    });
+    expect(response.body.data).toBe(1);
+    expect(response.body.message).toBe('게시글 생성 성공');
+  });
+
+  it('should update post', async () => {
+    const response = await request(app.getHttpServer()).put('/post').send({
+      postId: 1,
+      srcMemberId: 1,
+      title: 'test',
+      context: 'testContext',
+    });
+    expect(response.body.message).toBe('게시글 정보 수정 성공');
+  });
+
+  it('should delete post', async () => {
+    const response = await request(app.getHttpServer())
+      .delete('/post')
+      .query('postId=1');
+    expect(response.body.message).toBe('게시글 삭제 성공');
+  });
+
+  it('should find post list by member id', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/post')
+      .query('familyMemberId=1');
+
+    expect(response.body.message).toBe('게시글 조회 성공');
+    expect(response.body.data[0].title).toBe('testTitle');
+    expect(response.body.data[0].context).toBe('testContext');
+  });
 });
+

--- a/src/test/service/post.service.spec.ts
+++ b/src/test/service/post.service.spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import {
   CreatePostDto,
   PostService,
-  ResponsePostDto,
   UpdatePostDto,
 } from '../../domain/post';
 import { getRepositoryToken } from '@nestjs/typeorm';

--- a/src/test/service/post.service.spec.ts
+++ b/src/test/service/post.service.spec.ts
@@ -1,5 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { PostService } from '../../domain/post';
+import {
+  CreatePostDto,
+  PostService,
+  ResponsePostDto,
+  UpdatePostDto,
+} from '../../domain/post';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { FamilyMember, Post } from '../../infra/entities';
 
@@ -37,5 +42,82 @@ describe('PostService', () => {
 
   it('should be defined', () => {
     expect(postService).toBeDefined();
+  });
+
+  it('should create post', async () => {
+    const familyMember = FamilyMember.createFamilyMember(1, null, null);
+    const post = Post.createPost('test', 'test', new Date(), familyMember);
+    post.id = 1;
+
+    const createPostDto: CreatePostDto = {
+      srcMemberId: 1,
+      title: 'test',
+      context: 'test',
+      createdDate: new Date(),
+    };
+
+    jest
+      .spyOn(familyMemberRepository, 'findOne')
+      .mockResolvedValue(familyMember);
+    jest.spyOn(postRepository, 'save').mockResolvedValue(post);
+
+    const result = await postService.createPost(createPostDto);
+
+    expect(result).toEqual(1);
+  });
+
+  it('should update post', async () => {
+    const familyMember = FamilyMember.createFamilyMember(1, null, null);
+    const post = Post.createPost('test', 'test', new Date(), familyMember);
+    post.id = 1;
+
+    const updatePostDto: UpdatePostDto = {
+      postId: 1,
+      title: 'test',
+      context: 'test',
+      createdDate: new Date(),
+    };
+
+    jest.spyOn(postRepository, 'findOne').mockResolvedValue(post);
+    jest.spyOn(postRepository, 'save').mockResolvedValue(post);
+    jest
+      .spyOn(familyMemberRepository, 'findOne')
+      .mockResolvedValue(familyMember);
+
+    await postService.updatePost(updatePostDto);
+
+    expect(postRepository.save).toHaveBeenCalled();
+  });
+
+  it('should delete post', async () => {
+    const familyMember = FamilyMember.createFamilyMember(1, null, null);
+    const post = Post.createPost('test', 'test', new Date(), familyMember);
+    post.id = 1;
+
+    jest.spyOn(postRepository, 'findOne').mockResolvedValue(post);
+    jest.spyOn(postRepository, 'delete').mockResolvedValue(post);
+
+    await postService.deletePost(1);
+
+    expect(postRepository.delete).toHaveBeenCalled();
+  });
+
+  it('should get post list', async () => {
+    const familyMember = FamilyMember.createFamilyMember(1, null, null);
+    familyMember.id = 1;
+    const post = Post.createPost('test', 'test', new Date(), familyMember);
+    post.id = 1;
+
+    const postList = [post];
+
+    jest.spyOn(postRepository, 'find').mockResolvedValue(postList);
+    jest
+      .spyOn(familyMemberRepository, 'findOne')
+      .mockResolvedValue(familyMember);
+
+    const result = await postService.findPostListByMemberId(1);
+
+    expect(result.length).toEqual(1);
+    expect(result[0].title).toEqual('test');
   });
 });


### PR DESCRIPTION
### Motivations
- Restful API 원칙에 위배되는 api 변경

### Key Changes
- api path에 http Method 이름 존재할 시 제거
- GET, POST, PUT, DELETE의 알맞은 사용
- '_' 대신 '-' 사용
- 리소스 필터링 시, 추가적인 api 대신 Query 사용
