### PR TITLE
Fix: Family 삭제 시 FamilyMember 모두 삭제하도록 변경

### DIFF
--- a/src/domain/family/family.controller.ts
+++ b/src/domain/family/family.controller.ts
@@ -20,7 +20,7 @@ import { CustomApiResponse, ResponseCode } from '../../common';
 import { CustomApiOKResponse } from '../../common/api/response-ok.decorator';
 import { CustomApiCreatedResponse } from '../../common/api/response-created.decorator';
 import { JwtServiceAuthGuard } from '../../auth/guards/jwt-service-auth.guard';
-import {FamilyMemberService} from "../family_member";
+import { FamilyMemberService } from '../family_member';
 
 @ApiTags('가족 API')
 @Controller('family')

--- a/src/domain/family/family.controller.ts
+++ b/src/domain/family/family.controller.ts
@@ -23,7 +23,7 @@ import { JwtServiceAuthGuard } from '../../auth/guards/jwt-service-auth.guard';
 import { FamilyMemberService } from '../family_member';
 
 @ApiTags('가족 API')
-@Controller('family')
+@Controller('api/family')
 @UseGuards(JwtServiceAuthGuard)
 @ApiBearerAuth('access-token')
 export class FamilyController {

--- a/src/domain/family/family.controller.ts
+++ b/src/domain/family/family.controller.ts
@@ -29,7 +29,6 @@ import { FamilyMemberService } from '../family_member';
 export class FamilyController {
   constructor(
     private readonly familyService: FamilyService,
-    private readonly familyMemberService: FamilyMemberService,
   ) {}
 
   //회원이 속한 가족 정보 전송
@@ -96,7 +95,6 @@ export class FamilyController {
     type: CustomApiResponse<null>,
   })
   async deleteFamily(@Query('familyId') familyId: number) {
-    await this.familyMemberService.deleteAllFamilyMember(familyId);
     await this.familyService.deleteFamily(familyId);
     return CustomApiResponse.success(ResponseCode.FAMILY_DELETE_SUCCESS, null);
   }

--- a/src/domain/family/family.controller.ts
+++ b/src/domain/family/family.controller.ts
@@ -20,13 +20,17 @@ import { CustomApiResponse, ResponseCode } from '../../common';
 import { CustomApiOKResponse } from '../../common/api/response-ok.decorator';
 import { CustomApiCreatedResponse } from '../../common/api/response-created.decorator';
 import { JwtServiceAuthGuard } from '../../auth/guards/jwt-service-auth.guard';
+import {FamilyMemberService} from "../family_member";
 
 @ApiTags('가족 API')
 @Controller('family')
 @UseGuards(JwtServiceAuthGuard)
 @ApiBearerAuth('access-token')
 export class FamilyController {
-  constructor(private readonly familyService: FamilyService) {}
+  constructor(
+    private readonly familyService: FamilyService,
+    private readonly familyMemberService: FamilyMemberService,
+  ) {}
 
   //회원이 속한 가족 정보 전송
   @Get('')
@@ -92,6 +96,7 @@ export class FamilyController {
     type: CustomApiResponse<null>,
   })
   async deleteFamily(@Query('familyId') familyId: number) {
+    await this.familyMemberService.deleteAllFamilyMember(familyId);
     await this.familyService.deleteFamily(familyId);
     return CustomApiResponse.success(ResponseCode.FAMILY_DELETE_SUCCESS, null);
   }

--- a/src/domain/family/family.service.ts
+++ b/src/domain/family/family.service.ts
@@ -59,7 +59,7 @@ export class FamilyService {
     });
     for (const familyMember of familyMembers) {
       await this.userRepository.update(familyMember.user.id, {
-        belongsToFamily: () => 'BelongsToFamily - 1',
+        belongsToFamily: false,
       });
     }
 

--- a/src/domain/family/family.service.ts
+++ b/src/domain/family/family.service.ts
@@ -13,7 +13,7 @@ export class FamilyService {
     @InjectRepository(Family) private familyRepository: Repository<Family>,
     @InjectRepository(FamilyMember)
     private familyMemberRepository: Repository<FamilyMember>,
-    @InjectRepository(FamilyMember) private userRepository: Repository<User>,
+    @InjectRepository(User) private userRepository: Repository<User>,
   ) {}
 
   //가족 고유 해쉬키 생성

--- a/src/domain/family/family.service.ts
+++ b/src/domain/family/family.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import * as crypto from 'crypto';
 import { CreateFamilyDto, ResponseFamilyDto, UpdateFamilyDto } from './dto';
-import { Family } from '../../infra/entities';
+import { Family, FamilyMember, User } from '../../infra/entities';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { FamilyException } from '../../common/exception/family.exception';
@@ -11,6 +11,9 @@ import { ResponseCode } from '../../common';
 export class FamilyService {
   constructor(
     @InjectRepository(Family) private familyRepository: Repository<Family>,
+    @InjectRepository(FamilyMember)
+    private familyMemberRepository: Repository<FamilyMember>,
+    @InjectRepository(FamilyMember) private userRepository: Repository<User>,
   ) {}
 
   //가족 고유 해쉬키 생성
@@ -47,9 +50,22 @@ export class FamilyService {
     return ResponseFamilyDto.from(family);
   }
 
-  //가족 삭제
+  //가족과 가족 구성원 모두 삭제
   async deleteFamily(familyId: number): Promise<void> {
     await this.validateFamily(familyId);
+    const familyMembers = await this.familyMemberRepository.find({
+      where: { family: { id: familyId } },
+      relations: ['user'],
+    });
+    for (const familyMember of familyMembers) {
+      await this.userRepository.update(familyMember.user.id, {
+        belongsToFamily: () => 'BelongsToFamily - 1',
+      });
+    }
+
+    await this.familyMemberRepository.delete({
+      family: { id: familyId },
+    });
     await this.familyRepository.delete(familyId);
   }
 

--- a/src/domain/family_member/family-member.controller.ts
+++ b/src/domain/family_member/family-member.controller.ts
@@ -24,7 +24,7 @@ import { ResponseFamilyDto } from '../family';
 import { JwtServiceAuthGuard } from '../../auth/guards/jwt-service-auth.guard';
 
 @ApiTags('가족 멤버 API')
-@Controller('family-member')
+@Controller('api/family-member')
 @UseGuards(JwtServiceAuthGuard)
 @ApiBearerAuth('access-token')
 export class FamilyMemberController {

--- a/src/domain/family_member/family-member.service.ts
+++ b/src/domain/family_member/family-member.service.ts
@@ -40,7 +40,7 @@ export class FamilyMemberService {
     family.memberNumber += 1;
     // 가족에 속해 있다고 지정
     await this.userRepository.update(user.id, {
-      belongsToFamily: () => 'BelongsToFamily + 1',
+      belongsToFamily: true,
     });
     // 가족 구성원 수 증가
     await this.familyRepository.update(family.id, {
@@ -72,7 +72,7 @@ export class FamilyMemberService {
 
     await this.familyMemberRepository.delete(familyMemberId);
     await this.userRepository.update(user.id, {
-      belongsToFamily: () => 'BelongsToFamily - 1',
+      belongsToFamily: false,
     });
     await this.familyRepository.update(family.id, {
       memberNumber: () => 'Member_Number - 1',

--- a/src/domain/family_member/family-member.service.ts
+++ b/src/domain/family_member/family-member.service.ts
@@ -123,6 +123,26 @@ export class FamilyMemberService {
     return ResponseFamilyDto.from(familyMember.family);
   }
 
+  //가족 삭제 시 모든 구성원 제거
+  async deleteAllFamilyMember(familyId: number) {
+    await this.validateFamily(familyId);
+
+    // 가족에 속해있는 유저들의 belongsToFamily 0으로 초기화
+    const familyMembers = await this.familyMemberRepository.find({
+      where: { family: { id: familyId } },
+      relations: ['user'],
+    });
+    for (const familyMember of familyMembers) {
+      await this.userRepository.update(familyMember.user.id, {
+        belongsToFamily: () => 'BelongsToFamily - 1',
+      });
+    }
+
+    await this.familyMemberRepository.delete({
+      family: { id: familyId },
+    });
+  }
+
   //가족 ID를 통한 모든 가족 구성원 정보 반환
   async findAllFamilyMemberByFamilyId(
     familyId: number,

--- a/src/domain/family_member/family-member.service.ts
+++ b/src/domain/family_member/family-member.service.ts
@@ -123,26 +123,6 @@ export class FamilyMemberService {
     return ResponseFamilyDto.from(familyMember.family);
   }
 
-  //가족 삭제 시 모든 구성원 제거
-  async deleteAllFamilyMember(familyId: number) {
-    await this.validateFamily(familyId);
-
-    // 가족에 속해있는 유저들의 belongsToFamily 0으로 초기화
-    const familyMembers = await this.familyMemberRepository.find({
-      where: { family: { id: familyId } },
-      relations: ['user'],
-    });
-    for (const familyMember of familyMembers) {
-      await this.userRepository.update(familyMember.user.id, {
-        belongsToFamily: () => 'BelongsToFamily - 1',
-      });
-    }
-
-    await this.familyMemberRepository.delete({
-      family: { id: familyId },
-    });
-  }
-
   //가족 ID를 통한 모든 가족 구성원 정보 반환
   async findAllFamilyMemberByFamilyId(
     familyId: number,

--- a/src/domain/family_schedule/family-schedule.controller.ts
+++ b/src/domain/family_schedule/family-schedule.controller.ts
@@ -26,7 +26,7 @@ import { FamilyScheduleService } from './family-schedule.service';
 import { JwtServiceAuthGuard } from '../../auth/guards/jwt-service-auth.guard';
 
 @ApiTags('가족 일정 API')
-@Controller('family-schedule')
+@Controller('api/family-schedule')
 @UseGuards(JwtServiceAuthGuard)
 @ApiBearerAuth('access-token')
 export class FamilyScheduleController {

--- a/src/domain/interaction/interaction.controller.ts
+++ b/src/domain/interaction/interaction.controller.ts
@@ -16,7 +16,7 @@ import { ResponseInteractionDto } from './dto/response-interaction.dto';
 import { JwtServiceAuthGuard } from '../../auth/guards/jwt-service-auth.guard';
 
 @ApiTags('상호작용 API')
-@Controller('interaction')
+@Controller('api/interaction')
 @UseGuards(JwtServiceAuthGuard)
 @ApiBearerAuth('access-token')
 export class InteractionController {

--- a/src/domain/photo/photo.controller.ts
+++ b/src/domain/photo/photo.controller.ts
@@ -21,7 +21,7 @@ import { JwtServiceAuthGuard } from '../../auth/guards/jwt-service-auth.guard';
 import { CustomApiOKResponse } from '../../common/api/response-ok.decorator';
 
 @ApiTags('사진 API')
-@Controller('photo')
+@Controller('api/photo')
 @UseGuards(JwtServiceAuthGuard)
 @ApiBearerAuth('access-token')
 export class PhotoController {

--- a/src/domain/post/post.controller.ts
+++ b/src/domain/post/post.controller.ts
@@ -21,7 +21,7 @@ import { CustomApiOKResponse } from '../../common/api/response-ok.decorator';
 import { JwtServiceAuthGuard } from '../../auth/guards/jwt-service-auth.guard';
 
 @ApiTags('게시글 API')
-@Controller('post')
+@Controller('api/post')
 @UseGuards(JwtServiceAuthGuard)
 @ApiBearerAuth('access-token')
 export class PostController {

--- a/src/domain/user/user.controller.ts
+++ b/src/domain/user/user.controller.ts
@@ -29,7 +29,7 @@ import { CustomApiCreatedResponse } from '../../common/api/response-created.deco
 import { ResponseLoginDto } from '../../auth/dto/response-login.dto';
 
 @ApiTags('회원 API')
-@Controller('user')
+@Controller('api/user')
 export class UserController {
   constructor(
     private readonly userService: UserService,

--- a/src/module/family.module.ts
+++ b/src/module/family.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
 import { FamilyController, FamilyService } from '../domain/family';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Family } from '../infra/entities';
+import {Family, FamilyMember, User} from '../infra/entities';
 import { FamilyMemberService } from '../domain/family_member';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Family])],
+  imports: [TypeOrmModule.forFeature([Family, FamilyMember, User])],
 
   controllers: [FamilyController],
-  providers: [FamilyService, FamilyMemberService],
+  providers: [FamilyService],
 })
 export class FamilyModule {}

--- a/src/module/family.module.ts
+++ b/src/module/family.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { FamilyController, FamilyService } from '../domain/family';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Family } from '../infra/entities';
+import {FamilyMemberService} from "../domain/family_member";
 
 @Module({
   imports: [TypeOrmModule.forFeature([Family])],
 
   controllers: [FamilyController],
-  providers: [FamilyService],
+  providers: [FamilyService, FamilyMemberService],
 })
 export class FamilyModule {}

--- a/src/module/family.module.ts
+++ b/src/module/family.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { FamilyController, FamilyService } from '../domain/family';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Family } from '../infra/entities';
-import {FamilyMemberService} from "../domain/family_member";
+import { FamilyMemberService } from '../domain/family_member';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Family])],

--- a/src/test/e2e/family-member.e2e.spec.ts
+++ b/src/test/e2e/family-member.e2e.spec.ts
@@ -92,7 +92,7 @@ describe('FamilyMemberController (e2e)', () => {
 
   it('should create familyMember with path: /familymember/create (POST)', async () => {
     const response = await request(app.getHttpServer())
-      .post('/family-member')
+      .post('/api/family-member')
       .send({
         familyId: 1,
         userId: 1,
@@ -106,7 +106,7 @@ describe('FamilyMemberController (e2e)', () => {
 
   it('should update familyMember with path: /familymember/update (Patch)', async () => {
     const response = await request(app.getHttpServer())
-      .put('/family-member')
+      .put('/api/family-member')
       .send({
         familyMemberId: 1,
         role: 2,
@@ -118,7 +118,7 @@ describe('FamilyMemberController (e2e)', () => {
 
   it('should delete familyMember with path: /familymember/delete (Delete)', async () => {
     const response = await request(app.getHttpServer())
-      .delete('/family-member')
+      .delete('/api/family-member')
       .query({ id: 1 })
       .expect(200);
 
@@ -127,7 +127,7 @@ describe('FamilyMemberController (e2e)', () => {
 
   it('should get Family Member info with familyMember id', async () => {
     const response = await request(app.getHttpServer())
-      .get('/family-member')
+      .get('/api/family-member')
       .query({ id: 1 })
       .expect(200);
     expect(response.body.message).toEqual('가족 구성원 조회 성공');
@@ -138,7 +138,7 @@ describe('FamilyMemberController (e2e)', () => {
 
   it('should get Family Member info with user id', async () => {
     const response = await request(app.getHttpServer())
-      .get('/family-member/user')
+      .get('/api/family-member/user')
       .expect(200);
     expect(response.body.message).toEqual('가족 구성원 조회 성공');
     expect(response.body.data.familyMemberId).toEqual(1);
@@ -148,7 +148,7 @@ describe('FamilyMemberController (e2e)', () => {
 
   it('should get Family info with member id', async () => {
     const response = await request(app.getHttpServer())
-      .get('/family-member/family')
+      .get('/api/family-member/family')
       .query({ id: 1 })
       .expect(200);
 
@@ -159,7 +159,7 @@ describe('FamilyMemberController (e2e)', () => {
 
   it('should get Family Member list with family id', async () => {
     const response = await request(app.getHttpServer())
-      .get('/family-member/list')
+      .get('/api/family-member/list')
       .query({ id: 1 })
       .expect(200);
 

--- a/src/test/e2e/family-schedule.e2e.spec.ts
+++ b/src/test/e2e/family-schedule.e2e.spec.ts
@@ -76,7 +76,7 @@ describe('FamilyScheduleController', () => {
 
   it('should return familySchedule id with path: /create (POST)', async () => {
     const response = await request(app.getHttpServer())
-      .post('/family-schedule')
+      .post('/api/family-schedule')
       .send({
         scheduleName: 'test',
         scheduleDate: '2021-10-10',
@@ -90,7 +90,7 @@ describe('FamilyScheduleController', () => {
 
   it('should update FamilySchedule with path: /update (PATCH)', async () => {
     const response = await request(app.getHttpServer())
-      .put('/family-schedule')
+      .put('/api/family-schedule')
       .send({
         familyScheduleId: 1,
         scheduleName: 'test',
@@ -105,7 +105,7 @@ describe('FamilyScheduleController', () => {
 
   it('should delete FamilySchedule with path: /delete/:id (DELETE)', async () => {
     const response = await request(app.getHttpServer())
-      .delete('/family-schedule')
+      .delete('/api/family-schedule')
       .query({ id: 1 })
       .expect(200);
 
@@ -115,7 +115,7 @@ describe('FamilyScheduleController', () => {
 
   it('should return familySchedule info with path: /:id (GET)', async () => {
     const response = await request(app.getHttpServer())
-      .get('/family-schedule')
+      .get('/api/family-schedule')
       .query({ id: 1 })
       .expect(200);
 
@@ -126,7 +126,7 @@ describe('FamilyScheduleController', () => {
 
   it('should return familySchedule list with path: /list/:familyId (GET)', async () => {
     const response = await request(app.getHttpServer())
-      .get('/family-schedule/list')
+      .get('/api/family-schedule/list')
       .query({ familyId: 1, year: 2021, targetMonth: 10 })
       .expect(200);
 

--- a/src/test/e2e/family.e2e.spec.ts
+++ b/src/test/e2e/family.e2e.spec.ts
@@ -2,18 +2,21 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { FamilyService, ResponseFamilyDto } from '../../domain/family';
 import { INestApplication } from '@nestjs/common';
 import { Repository } from 'typeorm';
-import { Family } from '../../infra/entities';
+import { Family, FamilyMember } from '../../infra/entities';
 import { FamilyModule } from '../../module';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import * as request from 'supertest';
 import { JwtServiceAuthGuard } from '../../auth/guards/jwt-service-auth.guard';
 import { MockJwtAuthGuard } from './mockAuthGuard';
 import { PassportModule } from '@nestjs/passport';
+import { FamilyMemberService } from '../../domain/family_member';
 
 describe('FamilyController (e2e)', () => {
   let app: INestApplication;
   let mockFamilyService: Partial<FamilyService>;
+  let mockFamilyMemberService: Partial<FamilyMemberService>;
   let mockFamilyRepository: Partial<Repository<Family>>;
+  let mockFamilyMemberRepository: Partial<Repository<FamilyMember>>;
   const mockFamily: Family = Family.createFamily('test', 'testKeyCode');
   beforeEach(async () => {
     mockFamilyService = {
@@ -29,7 +32,16 @@ describe('FamilyController (e2e)', () => {
       updateFamily: jest.fn(),
     };
 
+    mockFamilyMemberService = {
+      deleteAllFamilyMember: jest.fn(),
+    };
+
     mockFamilyRepository = {
+      findOne: jest.fn().mockResolvedValue(mockFamily),
+      find: jest.fn(),
+    };
+
+    mockFamilyMemberRepository = {
       findOne: jest.fn().mockResolvedValue(mockFamily),
       find: jest.fn(),
     };
@@ -44,6 +56,10 @@ describe('FamilyController (e2e)', () => {
       .useValue(mockFamilyService)
       .overrideProvider(getRepositoryToken(Family))
       .useValue(mockFamilyRepository)
+      .overrideProvider(FamilyMemberService)
+      .useValue(mockFamilyMemberService)
+      .overrideProvider(getRepositoryToken(FamilyMember))
+      .useValue(mockFamilyMemberRepository)
       .overrideGuard(JwtServiceAuthGuard)
       .useClass(MockJwtAuthGuard)
       .compile();

--- a/src/test/e2e/interaction.e2e.spec.ts
+++ b/src/test/e2e/interaction.e2e.spec.ts
@@ -70,7 +70,7 @@ describe('InteractionController', () => {
   it('should create interaction', async () => {
     //given
     const response = await request(app.getHttpServer())
-      .post('/interaction')
+      .post('/api/interaction')
       .send({
         srcMemberId: 1,
         dstMemberId: 2,
@@ -85,7 +85,7 @@ describe('InteractionController', () => {
   it('should check interaction', async () => {
     //given
     const response = await request(app.getHttpServer())
-      .get('/interaction')
+      .get('/api/interaction')
       .query({ memberId: 2 })
       .expect(200);
 
@@ -98,7 +98,7 @@ describe('InteractionController', () => {
   it('should delete interaction', async () => {
     //given
     const response = await request(app.getHttpServer())
-      .delete('/interaction')
+      .delete('/api/interaction')
       .query({ memberId: 2 })
       .expect(200);
 

--- a/src/test/e2e/photo.e2e.spec.ts
+++ b/src/test/e2e/photo.e2e.spec.ts
@@ -65,7 +65,7 @@ describe('PhotoController (e2e)', () => {
 
   it('should create photo', async () => {
     const response = await request(app.getHttpServer())
-      .post('/photo')
+      .post('/api/photo')
       .send({
         s3imageUrl: 'test',
         name: 'test',
@@ -80,7 +80,7 @@ describe('PhotoController (e2e)', () => {
 
   it('should update photo', async () => {
     const response = await request(app.getHttpServer())
-      .put('/photo')
+      .put('/api/photo')
       .send({
         photoId: 1,
         name: 'test',
@@ -92,7 +92,7 @@ describe('PhotoController (e2e)', () => {
 
   it('should delete post', async () => {
     const response = await request(app.getHttpServer())
-      .delete('/photo')
+      .delete('/api/photo')
       .query({ photoId: 1 })
       .expect(200);
 
@@ -101,7 +101,7 @@ describe('PhotoController (e2e)', () => {
 
   it('should get photos', async () => {
     const response = await request(app.getHttpServer())
-      .get('/photo/list')
+      .get('/api/photo/list')
       .query({ familyId: 1, page: 1, limit: 10 })
       .expect(200);
 

--- a/src/test/e2e/post.e2e.spec.ts
+++ b/src/test/e2e/post.e2e.spec.ts
@@ -65,7 +65,7 @@ describe('PostController (e2e)', () => {
   });
 
   it('should create post', async () => {
-    const response = await request(app.getHttpServer()).post('/post').send({
+    const response = await request(app.getHttpServer()).post('/api/post').send({
       srcMemberId: 1,
       title: 'test',
       context: 'testContext',
@@ -76,7 +76,7 @@ describe('PostController (e2e)', () => {
   });
 
   it('should update post', async () => {
-    const response = await request(app.getHttpServer()).put('/post').send({
+    const response = await request(app.getHttpServer()).put('/api/post').send({
       postId: 1,
       srcMemberId: 1,
       title: 'test',
@@ -87,14 +87,14 @@ describe('PostController (e2e)', () => {
 
   it('should delete post', async () => {
     const response = await request(app.getHttpServer())
-      .delete('/post')
+      .delete('/api/post')
       .query('postId=1');
     expect(response.body.message).toBe('게시글 삭제 성공');
   });
 
   it('should find post list by member id', async () => {
     const response = await request(app.getHttpServer())
-      .get('/post')
+      .get('/api/post')
       .query('familyMemberId=1');
 
     expect(response.body.message).toBe('게시글 조회 성공');

--- a/src/test/service/family-member.service.spec.ts
+++ b/src/test/service/family-member.service.spec.ts
@@ -161,4 +161,39 @@ describe('FamilyMemberService', () => {
     const result = await familyMemberService.findAllFamilyMemberByFamilyId(1);
     expect(result[0].familyMemberId).toEqual(10);
   });
+
+  it('should find family-member by family-member id', async () => {
+    const family: Family = Family.createFamily('test', 'testKeyCode');
+    const user = User.createUser('test', 'test', 'test', 'test', 1, 1);
+    const familyMember = FamilyMember.createFamilyMember(1, family, user);
+    familyMember.setId(1);
+
+    jest
+      .spyOn(familyMemberRepository, 'findOne')
+      .mockResolvedValue(familyMember);
+
+    const result = await familyMemberService.findFamilyMemberByMemberId(1);
+    expect(result.familyMemberId).toEqual(1);
+  });
+
+  it('should delete all of family-member by family id', async () => {
+    const family: Family = Family.createFamily('test', 'testKeyCode');
+    const user = User.createUser('test', 'test', 'test', 'test', 1, 1);
+    const familyMember = FamilyMember.createFamilyMember(1, family, user);
+    user.belongsToFamily = true;
+
+    familyMember.setId(1);
+    user.id = 2;
+    family.setId(3);
+
+    jest.spyOn(familyRepository, 'findOne').mockResolvedValue(family);
+    jest
+      .spyOn(familyMemberRepository, 'find')
+      .mockResolvedValue([familyMember]);
+    jest.spyOn(familyMemberRepository, 'delete').mockResolvedValue(null);
+
+    await familyMemberService.deleteAllFamilyMember(3);
+    expect(familyMemberRepository.delete).toBeCalled();
+    expect(userRepository.update).toBeCalled();
+  });
 });

--- a/src/test/service/family-member.service.spec.ts
+++ b/src/test/service/family-member.service.spec.ts
@@ -175,25 +175,4 @@ describe('FamilyMemberService', () => {
     const result = await familyMemberService.findFamilyMemberByMemberId(1);
     expect(result.familyMemberId).toEqual(1);
   });
-
-  it('should delete all of family-member by family id', async () => {
-    const family: Family = Family.createFamily('test', 'testKeyCode');
-    const user = User.createUser('test', 'test', 'test', 'test', 1, 1);
-    const familyMember = FamilyMember.createFamilyMember(1, family, user);
-    user.belongsToFamily = true;
-
-    familyMember.setId(1);
-    user.id = 2;
-    family.setId(3);
-
-    jest.spyOn(familyRepository, 'findOne').mockResolvedValue(family);
-    jest
-      .spyOn(familyMemberRepository, 'find')
-      .mockResolvedValue([familyMember]);
-    jest.spyOn(familyMemberRepository, 'delete').mockResolvedValue(null);
-
-    await familyMemberService.deleteAllFamilyMember(3);
-    expect(familyMemberRepository.delete).toBeCalled();
-    expect(userRepository.update).toBeCalled();
-  });
 });


### PR DESCRIPTION
### Motivations
- Family 삭제 시 가족 구성원 제거 및 User 속성값 변경

### Key Changes
- Family 삭제 시 FamilyMember Entity 모두 제거
- User의 BelongsToFamily 모두 0으로 변경
- Family의 MemberCount -1
- Api BaseURL 변경
