### PR TITLE
Fix: Post API 및 PUT 메소드 오류 수정

### DIFF
--- a/src/domain/family/dto/request/update-family.dto.ts
+++ b/src/domain/family/dto/request/update-family.dto.ts
@@ -7,5 +7,5 @@ export class UpdateFamilyDto extends PartialType(CreateFamilyDto) {
   @ApiProperty({ example: 1, description: '가족 ID', nullable: false })
   @IsNotEmpty()
   @IsNumber()
-  familyId: number;
+  id: number;
 }

--- a/src/domain/family/family.service.ts
+++ b/src/domain/family/family.service.ts
@@ -71,7 +71,7 @@ export class FamilyService {
 
   //가족 정보 업데이트
   async updateFamily(updateFamilyDto: UpdateFamilyDto): Promise<void> {
-    const family = await this.validateFamily(updateFamilyDto.familyId);
+    const family = await this.validateFamily(updateFamilyDto.id);
     await this.familyRepository.update(
       { id: family.id },
       { ...updateFamilyDto },

--- a/src/domain/family_member/dto/request/update-family-member.dto.ts
+++ b/src/domain/family_member/dto/request/update-family-member.dto.ts
@@ -11,5 +11,5 @@ export class UpdateFamilyMemberDto extends PartialType(CreateFamilyMemberDto) {
   })
   @IsNotEmpty()
   @IsNumber()
-  readonly familyMemberId: number;
+  readonly id: number;
 }

--- a/src/domain/family_member/family-member.service.ts
+++ b/src/domain/family_member/family-member.service.ts
@@ -55,7 +55,7 @@ export class FamilyMemberService {
     updateFamilyMemberDto: UpdateFamilyMemberDto,
   ): Promise<void> {
     const familyMember = await this.validateFamilyMember(
-      updateFamilyMemberDto.familyMemberId,
+      updateFamilyMemberDto.id,
     );
     await this.familyMemberRepository.update(
       { id: familyMember.id },

--- a/src/domain/family_schedule/dto/request/update-family-schedule.dto.ts
+++ b/src/domain/family_schedule/dto/request/update-family-schedule.dto.ts
@@ -13,5 +13,5 @@ export class UpdateFamilyScheduleDto extends PartialType(
   })
   @IsNotEmpty()
   @IsNumber()
-  readonly familyScheduleId: number;
+  readonly id: number;
 }

--- a/src/domain/family_schedule/family-schedule.service.ts
+++ b/src/domain/family_schedule/family-schedule.service.ts
@@ -37,7 +37,7 @@ export class FamilyScheduleService {
 
   async updateFamilySchedule(updateFamilyScheduleDto: UpdateFamilyScheduleDto) {
     const familySchedule = await this.validateFamilySchedule(
-      updateFamilyScheduleDto.familyScheduleId,
+      updateFamilyScheduleDto.id,
     );
     await this.validateFamily(updateFamilyScheduleDto.familyId);
     await this.familyScheduleRepository.update(

--- a/src/domain/post/dto/request/update-post.dto.ts
+++ b/src/domain/post/dto/request/update-post.dto.ts
@@ -7,5 +7,5 @@ export class UpdatePostDto extends PartialType(CreatePostDto) {
   @ApiProperty({ example: 1, description: '포스트의 고유 ID' })
   @IsNotEmpty()
   @IsNumber()
-  postId: number;
+  id: number;
 }

--- a/src/domain/post/post.service.ts
+++ b/src/domain/post/post.service.ts
@@ -42,7 +42,7 @@ export class PostService {
   }
 
   async updatePost(updatePostDto: UpdatePostDto) {
-    const post = await this.validatePost(updatePostDto.postId);
+    const post = await this.validatePost(updatePostDto.id);
     await this.validateFamilyMember(updatePostDto.srcMemberId);
 
     await this.postRepository.update({ id: post.id }, { ...updatePostDto });

--- a/src/infra/entities/post.entity.ts
+++ b/src/infra/entities/post.entity.ts
@@ -19,7 +19,7 @@ export class Post {
   @Column('varchar', { name: 'Context', length: 50 })
   context: string;
 
-  @Column('date', { name: 'Created_Date' })
+  @Column('datetime', { name: 'Created_Date' })
   createdDate: Date;
 
   @ManyToOne(() => FamilyMember, (familyMember) => familyMember.sentPosts, {

--- a/src/test/service/family-member.service.spec.ts
+++ b/src/test/service/family-member.service.spec.ts
@@ -82,7 +82,7 @@ describe('FamilyMemberService', () => {
   it('should update family-member', async () => {
     const updateFamilyMemberDto: UpdateFamilyMemberDto = {
       role: 1,
-      familyMemberId: 1,
+      id: 1,
     };
     const family: Family = Family.createFamily('test', 'testKeyCode');
     const user: User = User.createUser('test', 'test', 'test', 'test', 1, 1);

--- a/src/test/service/family-schedule.service.spec.ts
+++ b/src/test/service/family-schedule.service.spec.ts
@@ -86,7 +86,7 @@ describe('FamilyScheduleService', () => {
     );
     familySchedule.setId(1);
     const updateFamilyScheduleDto = {
-      familyScheduleId: 1,
+      id: 1,
       scheduleName: 'testSchedule',
       scheduleYear: 2021,
       scheduleMonth: 10,

--- a/src/test/service/family.service.spec.ts
+++ b/src/test/service/family.service.spec.ts
@@ -126,7 +126,7 @@ describe('FamilyService', () => {
     //given
     const familyKeyCode = familyService.createFamilyKeyCode();
     const updateFamilyDto: UpdateFamilyDto = {
-      familyId: 1,
+      id: 1,
       familyName: 'testUpdated',
     };
     const family = Family.createFamily('test', familyKeyCode);

--- a/src/test/service/post.service.spec.ts
+++ b/src/test/service/post.service.spec.ts
@@ -94,7 +94,7 @@ describe('PostService', () => {
     post.id = 1;
 
     const updatePostDto: UpdatePostDto = {
-      postId: 1,
+      id: 1,
       title: 'test',
       context: 'test',
       srcMemberId: 1,


### PR DESCRIPTION
### Motivations
- Post API 및 PUT 메소드 오류 수정

### Key Changes
- UpdateDto에 고유 Id를 필드명과 일치하도록 수정
- post Entity의 createdDate를 Date가 아닌 DateTime으로 수정
